### PR TITLE
Replaces deprecated `List.zip/1` in favor of `Enum.zip/1`

### DIFF
--- a/lib/optimal/type.ex
+++ b/lib/optimal/type.ex
@@ -88,7 +88,7 @@ defmodule Optimal.Type do
       types = Tuple.to_list(types)
 
       [types, value]
-      |> List.zip()
+      |> Enum.zip()
       |> Enum.reduce(true, fn {type, value}, acc ->
         acc and matches_type?(type, value)
       end)


### PR DESCRIPTION
Hey folks, howdy! 🤠 

This pull request replaces a single [List.zip/1](https://hexdocs.pm/elixir/List.html#zip/1) call with [Enum.zip/1](https://hexdocs.pm/elixir/Enum.html#zip/1) instead, as `List.zip/2` was deprecated by Elixir 1.18 and it should be removed in a near future release [(see Elixir 1.18 changelog for details)](https://hexdocs.pm/elixir/1.18.0/changelog.html#4-hard-deprecations).


### Why is it necessary?

Currently, projects that depend on optimal directly or use libraries that depend on it show a deprecation warning when compiled with Elixir 1.18:
```
==> optimal
Compiling 5 files (.ex)
    warning: List.zip/1 is deprecated. Use Enum.zip/1 instead
    │
 91 │       |> List.zip()
    │               ~
    │
    └─ lib/optimal/type.ex:91:15: Optimal.Type.matches_type?/2

Generated optimal app
==> file_system
Compiling 7 files (.ex)
...
```


This can become a problem for projects upgrading to future versions of Elixir. 😬 


