### PR TITLE
ci: fix for release pr labeling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 name: Release
 


### PR DESCRIPTION
> Error: release-please failed: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}